### PR TITLE
update: memexec-bash, use execveat for execution

### DIFF
--- a/memexec-bash.sh
+++ b/memexec-bash.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-memexec() { bash -c 'cd /proc/$$;exec 4>mem;base64 -d<<<SInlSIHsEgQAAGoASLhrZXJuZWwAAFC4PwEAAEiJ574BAAAADwW4AAAAAL8AAAAASInmugAEAAAPBUiJwkiD+gB+EbgBAAAAvwMAAABIieYPBevSSLgvcHJvYy9zZUi6bGYvZmQvMwBqAFJQuDsAAABIiedIMfZIMdIPBbg8AAAASIP3Yw8FAAAAAAAAAAAAAAAAAAAAAAAAAAAA|dd bs=1 seek=$[$(cat syscall|cut -f9 -d" ")] >&4'; }
+memexec() { bash -c 'cd /proc/$$;exec 4>mem;base64 -d<<<SInlSIHsEgQAAGoASLhrZXJuZWwAAFC4PwEAAEiJ50gx9g8FSYnQuAAAAAC/AAAAAEiJ5roABAAADwVIicJIg/oAfhG4AQAAAL8DAAAASInmDwXr0rhCAQAATInHagBIieZIMdJIMclNMclNMdJBuAAQAAAPBbg8AAAAv2MAAAAPBQA=|dd bs=1 seek=$[$(cat syscall|cut -f9 -d" ")]>&4'; }
 
 # Example: cat /usr/bin/id | memexec 
 


### PR DESCRIPTION
uses the execveat trick (by @SkyperTHC ) to execute the created memfd, does not rely on hardcoded fd path.